### PR TITLE
修复查询多为表格记录时,反序列化失败的问题

### DIFF
--- a/src/Base/PostBitableV1AppsByAppTokenTablesByTableIdRecordsSearchResponseDto.cs
+++ b/src/Base/PostBitableV1AppsByAppTokenTablesByTableIdRecordsSearchResponseDto.cs
@@ -13,7 +13,7 @@ public record PostBitableV1AppsByAppTokenTablesByTableIdRecordsSearchResponseDto
     /// <para>必填：否</para>
     /// </summary>
     [JsonPropertyName("items")]
-    public AppTableRecord? Items { get; set; }
+    public AppTableRecord[]? Items { get; set; }
 
     /// <summary>
     /// <para>record 结果</para>


### PR DESCRIPTION
### 修复查询多维表格记录时,反序列化失败的问题
将`PostBitableV1AppsByAppTokenTablesByTableIdRecordsSearchResponseDto`中的`Items`字段改为数组