### PR TITLE
修复 富文本 消息  content 字段错误。

### DIFF
--- a/src/Im/Dtos/PostContent.cs
+++ b/src/Im/Dtos/PostContent.cs
@@ -11,12 +11,16 @@
 // </copyright>
 // <summary>富文本消息</summary>
 // ************************************************************************
+
+using System.Text.Json;
+
 namespace FeishuNetSdk.Im.Dtos
 {
     /// <summary>
     /// 富文本消息
     /// </summary>
     /// <param name="Post">富文本消息。post content格式请参见发送消息Content</param>
+    [JsonConverter(typeof(PostContentJsonConverter))]
     public record PostContent([property: JsonPropertyName("post")] I18nLanguage<PostContent.PostLanguage> Post = default!)
         : MessageContent("post")
     {
@@ -55,6 +59,20 @@ namespace FeishuNetSdk.Im.Dtos
             /// </summary>
             [JsonPropertyName("content")]
             public object[][] Content { get; set; } = Array.Empty<object[]>();
+        }
+    }
+
+    internal class PostContentJsonConverter : JsonConverter<PostContent>
+    {
+        public override PostContent Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var postLanguage = JsonSerializer.Deserialize<I18nLanguage<PostContent.PostLanguage>>(ref reader, options);
+            return new PostContent(postLanguage);
+        }
+
+        public override void Write(Utf8JsonWriter writer, PostContent value, JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, value.Post, options);
         }
     }
 }


### PR DESCRIPTION
使用 扩展方法 .SetContent() 构造富文本消息, 发送请求 后 会返回参数错误 
解决需要将 `PostContent` 的序列化从
``` json
{
  "post": {
    "zh_cn": {...},
    "en_us": {...}
  }
}
```
变为
```json
{
  "zh_cn": {...},
  "en_us": {...}
}
```
由于 不能同时继承自两个类型(即`MessageContent`, 和 `I18nLanguage<T>`)
且要复用 `I18nLanguage<T>` 这个类型， 需要使用`JsonConverter` 对 `PostContent` 这个类的序列化自定义